### PR TITLE
✨ Feat: 마이페이지 내 활동 보기 UI 및 게시물 검색 기능 구현(#52)

### DIFF
--- a/src/assets/icons/ChatAlert.svg
+++ b/src/assets/icons/ChatAlert.svg
@@ -1,0 +1,6 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path opacity="0.25" d="M22.9929 13.5697L9.07614 41.4184C5.72827 48.1176 10.5972 56 18.0833 56H45.9168C53.4027 56 58.2717 48.1176 54.924 41.4184L41.0072 13.5697C37.296 6.14344 26.704 6.14341 22.9929 13.5697Z" fill="#FF4155"/>
+<path d="M22.9929 13.5697L9.07614 41.4184C5.72827 48.1176 10.5972 56 18.0833 56H45.9168C53.4027 56 58.2717 48.1176 54.924 41.4184L41.0072 13.5697C37.296 6.14344 26.704 6.14341 22.9929 13.5697Z" stroke="#FF4155" stroke-width="4"/>
+<path d="M32 45.3333V45.36" stroke="#FF4155" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M32 21.3333V37.3333" stroke="#FF4155" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/components/Chat/NonSearch.jsx
+++ b/src/components/Chat/NonSearch.jsx
@@ -1,0 +1,77 @@
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import SadEmoji from '../../assets/icons/SadEmoji.svg';
+import { c, s, typography } from '../../styles/themeUtils';
+
+export default function NonSearch({ onWrite }) {
+  const navigate = useNavigate();
+
+  return (
+    <Wrapper>
+      <Emoji src={SadEmoji} alt="검색 결과 없음" />
+      <Title>아직 이 이야기는 조용하네요</Title>
+      <Description>
+        찾으시는 키워드로 지금<br />첫번째 이야기를 시작해보세요!
+      </Description>
+      <ActionButton
+        type="button"
+        onClick={() => {
+          if (typeof onWrite === 'function') {
+            onWrite();
+          } else {
+            navigate('/chat');
+          }
+        }}
+      >
+        이야기하기
+      </ActionButton>
+    </Wrapper>
+  );
+}
+
+const Wrapper = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  margin-top: 65px;
+  gap: ${s('md')};
+  padding: ${s('xl')} ${s('md')};
+  text-align: center;
+  color: ${c('neutral.black')};
+`;
+
+const Emoji = styled.img`
+  width: 64px;
+  height: 64px;
+`;
+
+const Title = styled.h2`
+  margin: 0;
+  ${typography('display02')};
+`;
+
+const Description = styled.p`
+  margin: 0;
+  ${typography('body01')};
+  color: ${c('neutral.black')};
+  white-space: pre-line;
+`;
+
+const ActionButton = styled.button`
+  margin-top: ${s('md')};
+  padding: ${s('md')} ${s('xl')};
+  width: calc(100% - 32px);
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: none;
+  background: ${c('brand.pink')};
+  color: ${c('neutral.white')};
+  ${typography('label01')};
+  cursor: pointer;
+
+  &:hover {
+    background: ${c('brand.darkPink')};
+  }
+`;
+

--- a/src/components/Chat/Post.jsx
+++ b/src/components/Chat/Post.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import Report from './Report';
 import styled from 'styled-components';
@@ -8,9 +8,12 @@ import CommentIcon from '../../assets/icons/ChatComment.svg';
 import ReportIcon from '../../assets/icons/Chatreport.svg';
 import { f, c } from '../../styles/themeUtils';
 
-export default function Post({ postData }) {
+export default function Post({ postData, highlightKeyword = '' }) {
   const [isReportOpen, setIsReportOpen] = useState(false);
   const navigate = useNavigate();
+
+  const normalizedKeyword = highlightKeyword.trim().toLowerCase();
+  const hasKeyword = normalizedKeyword.length > 0;
 
   const handleReportClick = () => setIsReportOpen(true);
   const closeReport = () => setIsReportOpen(false);
@@ -19,12 +22,37 @@ export default function Post({ postData }) {
     navigate(`/chat/${postId}`, { state: { post: postData.find(p => p.id === postId) } });
   };
 
+  const highlightText = useMemo(() => {
+    if (!hasKeyword) return null;
+
+    return text => {
+      if (typeof text !== 'string') return text;
+      const lower = text.toLowerCase();
+      const index = lower.indexOf(normalizedKeyword);
+      if (index === -1) return text;
+
+      const before = text.slice(0, index);
+      const match = text.slice(index, index + normalizedKeyword.length);
+      const after = text.slice(index + normalizedKeyword.length);
+
+      return (
+        <>
+          {before}
+          <Highlight>{match}</Highlight>
+          {after}
+        </>
+      );
+    };
+  }, [hasKeyword, normalizedKeyword]);
+
   const renderContent = (contentItem, index, postId) => {
     switch (contentItem.type) {
       case 'text':
         return (
           <ContentRow key={index}>
-            <ContentBox onClick={() => handlePostClick(postId)}>{contentItem.data}</ContentBox>
+            <ContentBox onClick={() => handlePostClick(postId)}>
+              {hasKeyword ? highlightText(contentItem.data) : contentItem.data}
+            </ContentBox>
             <ReportButton src={ReportIcon} alt="report" onClick={handleReportClick} />
           </ContentRow>
         );
@@ -156,6 +184,11 @@ const ContentBox = styled.div`
   line-height: 1.4;
   font-size: 14px;
   color: #333;
+`;
+
+const Highlight = styled.span`
+  font-weight: 700;
+  color: ${c('neutral.black')};
 `;
 
 const ImagesWrapper = styled.div`

--- a/src/components/Chat/Search.jsx
+++ b/src/components/Chat/Search.jsx
@@ -1,16 +1,13 @@
 import styled from 'styled-components';
-//import { c, f, s } from '../../styles/themeUtils';
+import { forwardRef } from 'react';
 
-export default function Search() {
-  return (
-    <>
-      <SearchBox placeholder="원하는 이야기를 검색해보세요." />
-    </>
-  );
-}
+const Search = forwardRef(({ value, onChange, placeholder = '원하는 이야기를 검색해보세요.' }, ref) => {
+  return <SearchBox ref={ref} value={value} onChange={onChange} placeholder={placeholder} />;
+});
+
+export default Search;
 
 const SearchBox = styled.input`
-  //임시
   margin: 10px 15px;
   width: 95%;
   height: 50px;
@@ -20,4 +17,5 @@ const SearchBox = styled.input`
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  font-size: 16px;
 `;

--- a/src/components/MyPage/ActivityLayout.jsx
+++ b/src/components/MyPage/ActivityLayout.jsx
@@ -1,0 +1,322 @@
+import { useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+import PageHeader from '../PageHeader';
+import Post from '../Chat/Post';
+import SearchIcon from '../../assets/icons/SearchIcon.svg';
+import { c, s, typography } from '../../styles/themeUtils';
+import { extractSearchableText } from './activityUtils';
+
+const DEFAULT_TABS = [
+  { key: 'story', label: '이야기', path: '/mypage/chat' },
+  { key: 'empathy', label: '공감', path: '/mypage/like' },
+  { key: 'comment', label: '댓글', path: '/mypage/comment' },
+];
+
+const filterItems = (items, keyword, type) => {
+  if (!keyword.trim()) return items;
+  const normalized = keyword.trim().toLowerCase();
+
+  if (type === 'comment') {
+    return items.filter(item =>
+      [item.commentText, item.postPreview, item.postNickname]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+        .includes(normalized)
+    );
+  }
+
+  return items.filter(post => extractSearchableText(post).includes(normalized));
+};
+
+export default function ActivityLayout({
+  headerTitle = 'My',
+  type,
+  items = [],
+  activeTab = 'story',
+  tabs = DEFAULT_TABS,
+  emptyTitle,
+  emptyDescription,
+}) {
+  const [keyword, setKeyword] = useState('');
+  const navigate = useNavigate();
+
+  const filteredItems = useMemo(
+    () => filterItems(items, keyword, type),
+    [items, keyword, type]
+  );
+
+  const hasItems = filteredItems.length > 0;
+
+  return (
+    <Screen>
+      <PageHeader title={headerTitle} onBack={() => window.history.back()} />
+      <PageContainer>
+
+        <SearchBarContainer>
+          <SearchBar>
+            <SearchInput
+              type="text"
+              value={keyword}
+              onChange={event => setKeyword(event.target.value)}
+              placeholder="원하는 이야기를 검색해보세요."
+            />
+            <SearchIconWrapper>
+              <SearchIconImg src={SearchIcon} alt="검색" />
+            </SearchIconWrapper>
+          </SearchBar>
+        </SearchBarContainer>
+
+        <TabsWrapper>
+          {tabs.map(tab => (
+            <TabButton
+              key={tab.key}
+              type="button"
+              $active={tab.key === activeTab}
+              onClick={() => navigate(tab.path)}
+            >
+              {tab.label}
+            </TabButton>
+          ))}
+        </TabsWrapper>
+
+
+        <ContentArea>
+          {type === 'comment' ? (
+            hasItems ? (
+              <CommentList>
+                {filteredItems.map(item => (
+                  <CommentCard key={item.id}>
+                    <CommentHeader>
+                      <CommentBadge>내 댓글</CommentBadge>
+                      <CommentMeta>{item.time}</CommentMeta>
+                    </CommentHeader>
+                    <CommentHighlight>{item.commentText}</CommentHighlight>
+                    {(item.postPreview || item.postNickname) && (
+                      <CommentSource>
+                        {item.postNickname ? `${item.postNickname} · ` : ''}
+                        {item.postPreview || '원문 텍스트 없음'}
+                      </CommentSource>
+                    )}
+                  </CommentCard>
+                ))}
+              </CommentList>
+            ) : (
+              <EmptyState>
+                <EmptyTitle>{emptyTitle}</EmptyTitle>
+                <EmptyDescription>{emptyDescription}</EmptyDescription>
+              </EmptyState>
+            )
+          ) : hasItems ? (
+            <PostListWrapper>
+              <Post postData={filteredItems} variant="card" />
+            </PostListWrapper>
+          ) : (
+            <EmptyState>
+              <EmptyTitle>{emptyTitle}</EmptyTitle>
+              <EmptyDescription>{emptyDescription}</EmptyDescription>
+            </EmptyState>
+          )}
+        </ContentArea>
+      </PageContainer>
+    </Screen>
+  );
+}
+
+const Screen = styled.div`
+  min-height: 100vh;
+  background: ${c('neutral.bg')};
+  display: flex;
+  flex-direction: column;
+`;
+
+const PageContainer = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: ${s('sm')};
+  padding: ${s('sm')} ${s('md')} ${s('xl')};
+  box-sizing: border-box;
+`;
+
+const TitleSection = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+`;
+
+const PageTitle = styled.h2`
+  ${typography('headline02')};
+  color: ${c('neutral.black')};
+  margin: 0;
+`;
+
+const TabsWrapper = styled.div`
+  display: flex;
+  justify-content: space-between;
+  gap: 32px;
+  background: transparent;
+  padding-top: ${s('xs')};
+`;
+
+const TabButton = styled.button`
+  flex: 1;
+  position: relative;
+  border: none;
+  background: transparent;
+  padding: 10px 0 8px;
+  cursor: pointer;
+  ${typography('body02')};
+  font-weight: ${({ $active }) => ($active ? 700 : 500)};
+  color: ${({ $active }) => ($active ? c('brand.pink') : c('neutral.black2'))};
+
+  &::after {
+    content: '';
+    position: absolute;
+    left: 50%;
+    bottom: 4px;
+    transform: translateX(-50%);
+    width: 38%;
+    height: 2px;
+    border-radius: 999px;
+    background: ${c('brand.pink')};
+    opacity: ${({ $active }) => ($active ? 1 : 0)};
+    transition: opacity 0.2s ease;
+  }
+`;
+
+const SearchBarContainer = styled.div`
+  padding: ${s('xs')} 0;
+`;
+
+const SearchBar = styled.div`
+  position: relative;
+  width: 100%;
+  display: flex;
+  align-items: center;
+`;
+
+const SearchInput = styled.input`
+  width: 100%;
+  padding: 12px 48px 12px 16px;
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: none;
+  background: ${c('neutral.white')};
+  ${typography('body01')};
+  color: ${c('neutral.black')};
+  outline: none;
+  box-sizing: border-box;
+
+  &::placeholder {
+    color: ${c('neutral.gray2')};
+  }
+`;
+
+const SearchIconWrapper = styled.div`
+  position: absolute;
+  right: 16px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+`;
+
+const SearchIconImg = styled.img`
+  width: 20px;
+  height: 20px;
+`;
+
+const ContentArea = styled.div`
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: ${s('md')};
+  padding-top: ${s('sm')};
+`;
+
+const PostListWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: ${s('md')};
+`;
+
+const EmptyState = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: ${s('sm')};
+  padding: ${s('xl')};
+  background: ${c('neutral.white')};
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: 1px solid rgba(149, 152, 163, 0.16);
+  box-shadow: 0 10px 24px rgba(26, 29, 45, 0.08);
+`;
+
+const EmptyTitle = styled.h2`
+  margin: 0;
+  ${typography('body01')};
+  color: ${c('neutral.black')};
+`;
+
+const EmptyDescription = styled.p`
+  margin: 0;
+  ${typography('body02')};
+  color: ${c('neutral.black2')};
+  text-align: center;
+`;
+
+const CommentList = styled.ul`
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: ${s('md')};
+`;
+
+const CommentCard = styled.li`
+  background: ${c('neutral.white')};
+  border-radius: ${({ theme }) => theme.radius.md};
+  border: 1px solid rgba(149, 152, 163, 0.12);
+  box-shadow: 0 10px 24px rgba(26, 29, 45, 0.08);
+  padding: ${s('md')};
+  display: flex;
+  flex-direction: column;
+  gap: ${s('sm')};
+`;
+
+const CommentHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+const CommentBadge = styled.span`
+  background: rgba(249, 64, 158, 0.1);
+  color: ${c('brand.pink')};
+  padding: 4px 10px;
+  border-radius: 999px;
+  ${typography('caption01')};
+`;
+
+const CommentMeta = styled.span`
+  ${typography('caption01')};
+  color: ${c('neutral.gray2')};
+`;
+
+const CommentHighlight = styled.p`
+  margin: 0;
+  ${typography('body01')};
+  color: ${c('neutral.black')};
+  white-space: pre-line;
+`;
+
+const CommentSource = styled.span`
+  ${typography('body02')};
+  color: ${c('neutral.black2')};
+`;
+

--- a/src/components/MyPage/activityUtils.js
+++ b/src/components/MyPage/activityUtils.js
@@ -1,0 +1,38 @@
+import { postData as initialPosts } from '../Chat/PostData';
+
+export const sanitizeNickname = nickname => nickname?.replace(/님!?$/, '').trim();
+
+export const ensurePostIds = posts => {
+  const generator = () => Date.now() + Math.random().toString(36).slice(2, 9);
+  return posts.map(post => (post.id ? post : { ...post, id: generator() }));
+};
+
+export const loadPostsFromStorage = () => {
+  const stored = localStorage.getItem('posts');
+  try {
+    return ensurePostIds(stored ? JSON.parse(stored) : initialPosts);
+  } catch (error) {
+    console.error('Failed to parse posts:', error);
+    return ensurePostIds(initialPosts);
+  }
+};
+
+export const extractSearchableText = post => {
+  const textChunks = [];
+  if (post.nickname) textChunks.push(post.nickname);
+  if (Array.isArray(post.content)) {
+    post.content.forEach(item => {
+      if (item?.type === 'text' && typeof item.data === 'string') {
+        textChunks.push(item.data);
+      }
+    });
+  }
+  return textChunks.join(' ').toLowerCase();
+};
+
+export const getPostPreview = post => {
+  if (!Array.isArray(post.content)) return '';
+  const textItem = post.content.find(item => item?.type === 'text');
+  return textItem?.data || '';
+};
+

--- a/src/components/MyPage/useActivityData.js
+++ b/src/components/MyPage/useActivityData.js
@@ -1,0 +1,98 @@
+import { useMemo } from 'react';
+import {
+  sanitizeNickname,
+  loadPostsFromStorage,
+  getPostPreview,
+} from './activityUtils';
+
+export function useActivityData() {
+  const posts = useMemo(() => loadPostsFromStorage(), []);
+
+  const userNickname = useMemo(() => {
+    const stored = localStorage.getItem('userNickname');
+    if (!stored) return null;
+    return sanitizeNickname(stored);
+  }, []);
+
+  const likedPostIds = useMemo(() => {
+    const saved = localStorage.getItem('userLikedPostIds');
+    if (!saved) return [];
+    try {
+      return JSON.parse(saved);
+    } catch {
+      return [];
+    }
+  }, []);
+
+  const commentedPostIds = useMemo(() => {
+    const saved = localStorage.getItem('userCommentedPostIds');
+    if (!saved) return [];
+    try {
+      return JSON.parse(saved);
+    } catch {
+      return [];
+    }
+  }, []);
+
+  const activityMap = useMemo(() => {
+    const likedSet = new Set(likedPostIds.map(String));
+    const commentedSet = new Set(commentedPostIds.map(String));
+
+    const normalizedNickname = userNickname;
+    const fallbackNickname = '익명의 사용자';
+
+    const postsByUser = normalizedNickname
+      ? posts.filter(post => sanitizeNickname(post.nickname) === normalizedNickname)
+      : [];
+
+    const fallbackPosts = posts.filter(
+      post => sanitizeNickname(post.nickname) === fallbackNickname
+    );
+
+    const storyPosts = postsByUser.length > 0 ? postsByUser : fallbackPosts;
+
+    const empathyPosts = posts.filter(post => likedSet.has(String(post.id)));
+
+    const candidateNicknames = new Set();
+    if (normalizedNickname) candidateNicknames.add(normalizedNickname);
+    candidateNicknames.add(fallbackNickname);
+
+    const allCommentEntries = posts.flatMap(post => {
+      if (!Array.isArray(post.comments)) return [];
+      return post.comments
+        .map((comment, index) => {
+          const sanitized = sanitizeNickname(comment.nickname);
+          return {
+            id: `${post.id}-${index}`,
+            postId: post.id,
+            postNickname: post.nickname,
+            postPreview: getPostPreview(post),
+            commentNickname: sanitized,
+            commentDisplayName: comment.nickname,
+            commentText: comment.text,
+            time: comment.time || post.time,
+          };
+        })
+        .filter(entry => candidateNicknames.has(entry.commentNickname));
+    });
+
+    const commentEntries = commentedSet.size
+      ? allCommentEntries.filter(entry => commentedSet.has(String(entry.postId)))
+      : allCommentEntries;
+
+    return {
+      story: storyPosts,
+      empathy: empathyPosts,
+      comment: commentEntries,
+    };
+  }, [posts, userNickname, likedPostIds, commentedPostIds]);
+
+  return {
+    posts,
+    userNickname,
+    stories: activityMap.story,
+    likes: activityMap.empathy,
+    comments: activityMap.comment,
+  };
+}
+

--- a/src/pages/Chat/Chat.jsx
+++ b/src/pages/Chat/Chat.jsx
@@ -1,8 +1,9 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef, useCallback } from 'react';
 import styled from 'styled-components';
 import Search from '../../components/Chat/Search';
 import ChatCatagory from '../../components/Chat/ChatCatagory';
 import Post from '../../components/Chat/Post';
+import NonSearch from '../../components/Chat/NonSearch';
 import WriteButton from '../../components/Chat/WriteButton';
 import WritePost from '../../components/Chat/WritePost';
 import { postData as initialData } from '../../components/Chat/PostData.js';
@@ -12,6 +13,7 @@ export default function Chat() {
   const [openWrite, setOpenWrite] = useState(false);
   const [posts, setPosts] = useState([]);
   const [selectedCategory, setSelectedCategory] = useState('전체');
+  const [searchKeyword, setSearchKeyword] = useState('');
   const isFirstLoad = useRef(true);
 
   //고유 ID 생성 함수
@@ -52,18 +54,41 @@ export default function Chat() {
   };
 
   // 카테고리 필터링
-  const filteredPosts =
-    selectedCategory === '전체' ? posts : posts.filter(post => post.category === selectedCategory);
+  const filteredPosts = useMemo(() => {
+    const categoryFiltered =
+      selectedCategory === '전체'
+        ? posts
+        : posts.filter(post => post.category === selectedCategory);
+
+    if (!searchKeyword.trim()) return categoryFiltered;
+
+    const keyword = searchKeyword.trim().toLowerCase();
+
+    return categoryFiltered.filter(post =>
+      post.content.some(item => {
+        if (item.type !== 'text' || typeof item.data !== 'string') return false;
+        return item.data.toLowerCase().includes(keyword);
+      })
+    );
+  }, [posts, selectedCategory, searchKeyword]);
+
+  const handleSearchChange = useCallback(event => {
+    setSearchKeyword(event.target.value);
+  }, []);
 
   return (
     <ChatWrapper>
       <ChatTop>
-        <Search />
+        <Search value={searchKeyword} onChange={handleSearchChange} />
         <ChatCatagory selectedCategory={selectedCategory} onSelectCategory={setSelectedCategory} />
       </ChatTop>
 
       <ChatBottom>
-        <Post postData={filteredPosts} />
+        {filteredPosts.length > 0 ? (
+          <Post postData={filteredPosts} highlightKeyword={searchKeyword} />
+        ) : (
+          <NonSearch onWrite={() => setOpenWrite(true)} />
+        )}
         <WriteButton onClick={() => setOpenWrite(true)} />
         {openWrite && <WritePost onClose={() => setOpenWrite(false)} onAddPost={handleAddPost} />}
       </ChatBottom>

--- a/src/pages/MyPage/MyActivity/MyActivityChat.jsx
+++ b/src/pages/MyPage/MyActivity/MyActivityChat.jsx
@@ -1,0 +1,17 @@
+import ActivityLayout from '../../../components/MyPage/ActivityLayout';
+import { useActivityData } from '../../../components/MyPage/useActivityData';
+
+export default function MyActivityChat() {
+  const { stories } = useActivityData();
+
+  return (
+    <ActivityLayout
+      type="story"
+      items={stories}
+      activeTab="story"
+      emptyTitle="아직 작성한 이야기가 없어요."
+      emptyDescription="다른 이야기들을 살펴보고 새로운 이야기를 시작해보세요!"
+    />
+  );
+}
+

--- a/src/pages/MyPage/MyActivity/MyActivityComment.jsx
+++ b/src/pages/MyPage/MyActivity/MyActivityComment.jsx
@@ -1,0 +1,17 @@
+import ActivityLayout from '../../../components/MyPage/ActivityLayout';
+import { useActivityData } from '../../../components/MyPage/useActivityData';
+
+export default function MyActivityComment() {
+  const { comments } = useActivityData();
+
+  return (
+    <ActivityLayout
+      type="comment"
+      items={comments}
+      activeTab="comment"
+      emptyTitle="댓글을 남긴 기록이 없어요."
+      emptyDescription="관심 있는 이야기에 댓글을 남겨보세요!"
+    />
+  );
+}
+

--- a/src/pages/MyPage/MyActivity/MyActivityLike.jsx
+++ b/src/pages/MyPage/MyActivity/MyActivityLike.jsx
@@ -1,0 +1,17 @@
+import ActivityLayout from '../../../components/MyPage/ActivityLayout';
+import { useActivityData } from '../../../components/MyPage/useActivityData';
+
+export default function MyActivityLike() {
+  const { likes } = useActivityData();
+
+  return (
+    <ActivityLayout
+      type="empathy"
+      items={likes}
+      activeTab="empathy"
+      emptyTitle="공감한 이야기가 아직 없어요."
+      emptyDescription="마음에 드는 이야기에 공감을 눌러보세요!"
+    />
+  );
+}
+

--- a/src/pages/MyPage/MyPage.jsx
+++ b/src/pages/MyPage/MyPage.jsx
@@ -244,6 +244,10 @@ export default function MyPage({
     navigate('/mypage/profile');
   };
 
+  const handleOpenMyActivity = path => {
+    navigate(path);
+  };
+
   // 로그인 상태 변경 감지
   useEffect(() => {
     const handleStorageChange = () => {
@@ -370,13 +374,13 @@ export default function MyPage({
           <Section>
             <SectionTitle>내 활동 보기</SectionTitle>
             <MenuList>
-              <MenuItem>
+              <MenuItem onClick={() => handleOpenMyActivity('/mypage/chat')}>
                 <MenuItemLabel>내가 쓴 이야기</MenuItemLabel>
               </MenuItem>
-              <MenuItem>
+              <MenuItem onClick={() => handleOpenMyActivity('/mypage/like')}>
                 <MenuItemLabel>내가 공감한 이야기</MenuItemLabel>
               </MenuItem>
-              <MenuItem className="with-border">
+              <MenuItem className="with-border" onClick={() => handleOpenMyActivity('/mypage/comment')}>
                 <MenuItemLabel>내가 댓글단 이야기</MenuItemLabel>
               </MenuItem>
             </MenuList>

--- a/src/router/index.jsx
+++ b/src/router/index.jsx
@@ -10,6 +10,9 @@ import Chat from '../pages/Chat/Chat';
 import Comments from '../pages/Chat/Comments';
 import Game from '../pages/Game/Game';
 import MyPage from '../pages/MyPage/MyPage';
+import MyActivityChat from '../pages/MyPage/MyActivity/MyActivityChat';
+import MyActivityLike from '../pages/MyPage/MyActivity/MyActivityLike';
+import MyActivityComment from '../pages/MyPage/MyActivity/MyActivityComment';
 import Nickname from '../pages/Signup/Nickname';
 import Login from '../pages/Login/Login';
 import SignUp from '../pages/Signup/SignUp';
@@ -102,6 +105,9 @@ export default function Router() {
             </MainLayout>
           }
         />
+        <Route path="/mypage/chat" element={<MyActivityChat />} />
+        <Route path="/mypage/like" element={<MyActivityLike />} />
+        <Route path="/mypage/comment" element={<MyActivityComment />} />
         {/* 비밀번호 변경 페이지 (Header 제거, Navbar 유지)*/}
         <Route path="/mypage/changepassword" element={<ChangePassword />} />
         {/* 프로필 변경 페이지 (Header 제거, Navbar 유지)*/}


### PR DESCRIPTION
## 🧩 Pull Request Summary

<!-- 어떤 작업을 했는지 간략히 설명해주세요 -->

마이페이지 내 활동 보기(내가 쓴 이야기, 내가 댓글단 이야기, 내가 공감한 이야기)
/chat에서의 검색바 기능->검색결과 없는 화면/검색결과 있을 때의 해당 게시물 정렬 및 텍스트 볼드체 표시

## 🔗 Related Issue

#52 

---

## 🧱 작업 유형 (Issue Type)

<!-- 해당 작업의 유형에 체크해주세요 -->

- [x] ✨ Feat (새 기능 추가)
- [ ] 🐛 Fix (버그 수정)
- [ ] 💄 Design (UI 수정)
- [ ] ♻️ Refactor (리팩토링)
- [ ] 🧱 Setting (환경 세팅)
- [ ] 🧹 Chore (기타 잡일)

---

## ✅ 작업 내용 (What I did)

- [x] 마이페이지 내 활동 보기 UI
- [x] /chat 검색바 기능
- [x] 검색결과 없는 페이지

---

