### PR TITLE
✨ Feat: 마이페이지 비밀번호 수정하기 api 연동(#115)

### DIFF
--- a/src/api/mypage/chat.js
+++ b/src/api/mypage/chat.js
@@ -159,17 +159,27 @@ const adaptPost = rawPost => {
     contentItems.push({ type: 'text', data: '내용이 없습니다.' });
   }
 
+  // PostItem 컴포넌트가 기대하는 형식으로 변환
+  // content는 문자열 또는 contentItems 배열 둘 다 지원
+  const contentString = content || title || '';
+  
   return {
     id,
     nickname: author || '익명',
-    content: contentItems,
+    author: author || '익명', // PostItem에서 author도 사용
+    content: contentString, // PostItem이 문자열로 기대
+    contentItems: contentItems, // PostContent에서 배열로 사용할 수 있도록
     like: Number(likeCount) || 0,
+    likeCount: Number(likeCount) || 0, // PostItem에서 likeCount 사용
     comment: Number(commentCount) || 0,
+    commentCount: Number(commentCount) || 0, // PostItem에서 commentCount 사용
     comments: [],
     time: formatRelativeTime(createdAt || updatedAt),
+    createdAt: createdAt || updatedAt, // PostItem에서 createdAt 사용
     category: tagName || postType || '기타',
     postType: postType || null,
     profileImageUrl: profileImageUrl || null,
+    poll: poll || null, // PostItem에서 poll 직접 확인
     raw: rawPost,
   };
 };

--- a/src/api/mypageService.js
+++ b/src/api/mypageService.js
@@ -210,14 +210,14 @@ export async function updateNickname({ slug, nickname }) {
 export async function changePassword({ slug, currentPassword, newPassword }) {
   const encodedSlug = encodeURIComponent(slug.trim());
   
-  const requestBody = {
-    currentPassword: currentPassword.trim(),
-    newPassword: newPassword.trim(),
-  };
+  // FormData 사용
+  const formData = new FormData();
+  formData.append('currentPassword', currentPassword.trim());
+  formData.append('newPassword', newPassword.trim());
   
   try {
     // 디버깅: 요청 정보 로깅
-    console.log('비밀번호 변경 API 요청:', {
+    console.log('비밀번호 변경 API 요청 (FormData):', {
       url: `/${encodedSlug}/mypage/password`,
       slug: encodedSlug,
       withCredentials: true, // axios 인스턴스에서 설정됨
@@ -225,10 +225,10 @@ export async function changePassword({ slug, currentPassword, newPassword }) {
     
     const response = await apiClient.patch(
       `/${encodedSlug}/mypage/password`,
-      requestBody,
+      formData,
       {
         headers: {
-          'Content-Type': 'application/json',
+          'Content-Type': 'multipart/form-data',
         },
         withCredentials: true, // 명시적으로 설정
       }

--- a/src/components/MyPage/ActivityLayout.jsx
+++ b/src/components/MyPage/ActivityLayout.jsx
@@ -90,7 +90,7 @@ export default function ActivityLayout({
     content = hasItems
       ? (
         <PostListWrapper>
-          <Post postData={filteredItems} variant="card" />
+          <Post postData={filteredItems} />
         </PostListWrapper>
         )
       : renderStatusCard(emptyTitle, emptyDescription);


### PR DESCRIPTION
## 🧩 Pull Request Summary

<!-- 어떤 작업을 했는지 간략히 설명해주세요 -->

 Feat: 마이페이지 비밀번호 수정하기 api 연동

---

## 🔗 Related Issue

#115 

---

## 🧱 작업 유형 (Issue Type)

<!-- 해당 작업의 유형에 체크해주세요 -->

- [x] ✨ Feat (새 기능 추가)
- [ ] 🐛 Fix (버그 수정)
- [ ] 💄 Design (UI 수정)
- [ ] ♻️ Refactor (리팩토링)
- [ ] 🧱 Setting (환경 세팅)
- [ ] 🧹 Chore (기타 잡일)

---

## ✅ 작업 내용 (What I did)

<!-- 주요 수정 사항을 간략하게 나열해주세요 -->

- [x] 마이페이지 비밀번호 수정하기 api 연동 완료(프로필 수정 관련은 formData 전송 방식으로 통일)

---

## 📸 Screenshots (선택사항)

<img width="970" height="360" alt="image" src="https://github.com/user-attachments/assets/b9f65982-5dd5-4ff4-b50a-d5de82d3c7c6" />
<img width="888" height="172" alt="image" src="https://github.com/user-attachments/assets/c2d16034-4a7b-4dbb-8f48-f6d6166a5c6f" />

---
